### PR TITLE
Change Order of Commands

### DIFF
--- a/How_Tos/How_To_DO_Ubuntu_on_Digital_Ocean.md
+++ b/How_Tos/How_To_DO_Ubuntu_on_Digital_Ocean.md
@@ -25,8 +25,8 @@ $ pip3 install --upgrade pip
 ```sh
 $ cd ~
 $ wget "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
-$ sudo dpkg -i google-chrome-stable_current_amd64.deb
 $ sudo apt-get install -y -f
+$ sudo dpkg -i google-chrome-stable_current_amd64.deb
 $ sudo rm google-chrome-stable_current_amd64.deb
 ```
 


### PR DESCRIPTION
In the old order you'll get dependency errors for google chrome-stable. You first need to install dependencies than you can do the dpkg command